### PR TITLE
deps: Bump Go to 1.19

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.repository_owner == 'placeholder-app' }}
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       # Clone repository

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ You can simulate requests to the API, or run HTTP-based testing.
 
 # Requirements & Dependencies
 
-- Go 1.19
+- Go 1.19 (Minimum)
 - [gin-gonic/gin](github.com/gin-gonic/gin)
 - openapi-generator-cli (For documentation only)
 


### PR DESCRIPTION
This drops support for anything under 1.19, and removes the MacOS unit testing runner.